### PR TITLE
BUGFIX: Correct validate translation entity

### DIFF
--- a/code/formfields/RegexTextField.php
+++ b/code/formfields/RegexTextField.php
@@ -25,7 +25,7 @@ class RegexTextField extends TextField {
 	public function validate($validator) {
 		if($this->value && $this->regex) {
 			if(!preg_match($this->regex, $this->value)) {
-				$message = _t('Addressable.SUBURB', 'Please enter a valid format for "%s".');
+				$message = _t('RegexTextField.VALIDATE', 'Please enter a valid format for "%s".');
 				$validator->validationError($this->name, sprintf($message, $this->name), 'validation');
 				return false;
 			}


### PR DESCRIPTION
Started using this module and noticed that the validation message was being translated as the suburb. Let me know if the new entity is ok.
