### PR TITLE
BUGFIX: Allow alphanumeric Postcodes in getFullAddress

### DIFF
--- a/code/Addressable.php
+++ b/code/Addressable.php
@@ -148,7 +148,7 @@ class Addressable extends DataExtension {
 	 * @return string
 	 */
 	public function getFullAddress() {
-		return sprintf('%s, %s, %s %d, %s',
+		return sprintf('%s, %s, %s %s, %s',
 			$this->owner->Address,
 			$this->owner->Suburb,
 			$this->owner->State,


### PR DESCRIPTION
Postcodes in the UK are alphanumeric but the getFullAddress function was assuming numeric only Postcodes. This was causing alphanumeric Postcodes to get rendered as '0'.
