### PR TITLE
URL change to googleapis.com for Static Image

### DIFF
--- a/templates/AddressMap.ss
+++ b/templates/AddressMap.ss
@@ -1,5 +1,5 @@
 <div class="addressMap">
 	<a href="http://maps.google.com/?q=$Address">
-		<img src="http://maps.google.com/maps/api/staticmap?size={$Width}x{$Height}&markers=$Address&sensor=false" alt="$FullAddress.ATT" />
+		<img src="http://maps.googleapis.com/maps/api/staticmap?size={$Width}x{$Height}&markers=$Address&sensor=false" alt="$FullAddress.ATT" />
 	</a>
 </div>


### PR DESCRIPTION
Hi Andrew, just noticed that the image call is using the maps.google.com format which has now been (or close to) phased out for the Google Map's & Geocoding API's in favour of the maps.googleapis.com format.

The template is fully functional without this change - merely suggesting this with regards to possible deprecation moving forwards. The maps.googleapis.com is now also the supported url accoding to the Static Maps API documentation.
