### PR TITLE
Don't automatically add address fields if they already exist.

### DIFF
--- a/code/Addressable.php
+++ b/code/Addressable.php
@@ -86,7 +86,9 @@ class Addressable extends DataExtension {
 	}
 
 	public function updateFrontEndFields(FieldList $fields) {
-		foreach ($this->getAddressFields() as $field) $fields->push($field);
+		if(!$fields->dataFieldByName("Address")){
+			$fields->merge($this->getAddressFields());
+		}
 	}
 
 	public function populateDefaults() {


### PR DESCRIPTION
I had to do this to be able to prevent my changes from being overridden. I added my own address fields via a DataExtension, but the Addressable extension overrode them.

Even better than this would be to perhaps disable adding these fields on a per-model basis. So you could configure in your yaml as such:

``` yaml
Order:
   add_frontend_fields: false
```

Or perhaps a global conf

``` yaml
Addressable:
   add_frontend_fields: false
```
