### PR TITLE
Require framework only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "silverstripe/cms": "^4.0",
+        "silverstripe/framework": "^4.0",
         "guzzlehttp/guzzle": "^5.3.1|^6.2.1"
     },
     "require-dev": {

--- a/tests/GeocodableTest.php
+++ b/tests/GeocodableTest.php
@@ -5,7 +5,7 @@ namespace Symbiote\Addressable\Tests;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use Symbiote\Addressable\Geocodable;
-use Symbiote\Addressable\GeocodeService;
+use Symbiote\Addressable\GoogleGeocodeService;
 
 class GeocodableTest extends SapphireTest
 {
@@ -32,7 +32,7 @@ class GeocodableTest extends SapphireTest
 
         $e = $record->getLastGeocodableException();
         if ($e &&
-            $e->getStatus() === GeocodeService::ERROR_OVER_QUERY_LIMIT) {
+            $e->getStatus() === GoogleGeocodeService::ERROR_OVER_QUERY_LIMIT) {
             $this->markTestSkipped(
                 'Skipping '. get_class($this).'::'.__FUNCTION__.'() due to being over quota limit. Exception: '.$e->getMessage()
             );
@@ -60,7 +60,7 @@ class GeocodableTest extends SapphireTest
 
         $e = $record->getLastGeocodableException();
         if ($e &&
-            $e->getStatus() === GeocodeService::ERROR_OVER_QUERY_LIMIT) {
+            $e->getStatus() === GoogleGeocodeService::ERROR_OVER_QUERY_LIMIT) {
             $this->markTestSkipped(
                 'Skipping '. get_class($this).'::'.__FUNCTION__.'() due to being over quota limit. Exception: '.$e->getMessage()
             );
@@ -69,7 +69,7 @@ class GeocodableTest extends SapphireTest
         }
 
         $this->assertEquals(
-            GeocodeService::ERROR_ZERO_RESULTS,
+            GoogleGeocodeService::ERROR_ZERO_RESULTS,
             $e->getStatus()
         );
     }


### PR DESCRIPTION
Changed to require silverstripe/framework. Tested and don't seem to have any impact. 

Upon testing, fixed `tests/GeocodableTest.php` since `GeocodeService` have been renamed to `GoogleGeocodeService` from #62 merge.