### PR TITLE
Fix GOOGLE_API_KEY=false not allowing use  of config API values

### DIFF
--- a/tests/GeocodableApiValuesTest.php
+++ b/tests/GeocodableApiValuesTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Symbiote\Addressable\Tests;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Environment;
+use SilverStripe\Dev\SapphireTest;
+use Symbiote\Addressable\GoogleGeocodeService;
+
+class GeocodableApiValuesTest extends SapphireTest
+{
+
+    protected $envApiKey = 'env-key';
+
+    protected $googleGeocodeServiceApiKey = 'google-geocode-service-key';
+
+    protected $geocodeServiceApiKey = 'geocode-service-key';
+
+    protected $googleGeocodeServiceApiUrl = 'https://example.com/googleGeocodeServiceApiUrl';
+
+    protected $geocodeServiceApiUrl = 'https://example.com/geocodeServiceApiUrl';
+
+    /**
+     * Set up config
+     */
+    public function setUp() {
+        parent::setUp();
+        Environment::setEnv('GOOGLE_API_KEY', $this->envApiKey);
+        Config::inst()->update( GoogleGeocodeService::class, 'google_api_key', $this->googleGeocodeServiceApiKey );
+        Config::inst()->update( 'Symbiote\\Addressable\\GeocodeService', 'google_api_key', $this->geocodeServiceApiKey );
+        Config::inst()->update( GoogleGeocodeService::class, 'google_api_url', $this->googleGeocodeServiceApiUrl );
+        Config::inst()->update( 'Symbiote\\Addressable\\GeocodeService', 'google_api_url', $this->geocodeServiceApiUrl );
+    }
+
+    /**
+     * Reset config
+     */
+    public function tearDown() {
+        parent::tearDown();
+        Environment::setEnv('GOOGLE_API_KEY', false);
+        Config::inst()->update( GoogleGeocodeService::class, 'google_api_key', null );
+        Config::inst()->update( 'Symbiote\\Addressable\\GeocodeService', 'google_api_key', null );
+        Config::inst()->update( GoogleGeocodeService::class, 'google_api_url', null );
+        Config::inst()->update( 'Symbiote\\Addressable\\GeocodeService', 'google_api_url', null );
+    }
+
+    /**
+     * Test setting and getting API key, including legacy config
+     */
+    public function testApiKeySetGet() {
+        $service = new GoogleGeocodeService();
+
+        $key = $service->getApiKey();
+        $this->assertEquals($this->envApiKey, $key, "The API key should be the key set from environment");
+
+        // false environment value
+        Environment::setEnv('GOOGLE_API_KEY', false);
+        $key = $service->getApiKey();
+        $this->assertEquals($this->googleGeocodeServiceApiKey, $key, "The API key should be the key set via config API on GoogleGeocodeService");
+
+        // null environment value
+        Environment::setEnv('GOOGLE_API_KEY', null);
+        $key = $service->getApiKey();
+        $this->assertEquals($this->googleGeocodeServiceApiKey, $key, "The API key should be the key set via config API on GoogleGeocodeService");
+
+        // empty string value
+        Environment::setEnv('GOOGLE_API_KEY', false);
+        Config::inst()->update( GoogleGeocodeService::class, 'google_api_key', '' );
+        $key = $service->getApiKey();
+        $this->assertEquals($this->geocodeServiceApiKey, $key, "The API key should be the key set via config API on legacy GeocodeService");
+
+        // null value
+        Environment::setEnv('GOOGLE_API_KEY', false);
+        Config::inst()->update( GoogleGeocodeService::class, 'google_api_key', null );
+        $key = $service->getApiKey();
+        $this->assertEquals($this->geocodeServiceApiKey, $key, "The API key should be the key set via config API on legacy GeocodeService");
+
+        // lack of config value should throw an \Exception
+        Environment::setEnv('GOOGLE_API_KEY', false);
+        Config::inst()->update( GoogleGeocodeService::class, 'google_api_key', null );
+        Config::inst()->update( 'Symbiote\\Addressable\\GeocodeService', 'google_api_key', null );
+        try {
+            $key = $service->getApiKey();
+            $this->assertTrue(false, "Lack of an API key should trigger an \Exception");
+        } catch (\Exception $e) {
+            // noop
+        }
+
+    }
+
+    /**
+     * Test setting and getting API URL, including legacy config
+     */
+    public function testApiUrlSetGet() {
+        $service = new GoogleGeocodeService();
+
+        $url = $service->getApiUrl();
+        $this->assertEquals($this->googleGeocodeServiceApiUrl, $url, "The API URL should be the URL set via config API on GoogleGeocodeService");
+
+        // empty string value
+        Config::inst()->update( GoogleGeocodeService::class, 'google_api_url', '' );
+        $url = $service->getApiUrl();
+        $this->assertEquals($this->geocodeServiceApiUrl, $url, "The API url should be the url set via config API on legacy GeocodeService");
+
+        // null value
+        Config::inst()->update( GoogleGeocodeService::class, 'google_api_url', null );
+        $url = $service->getApiUrl();
+        $this->assertEquals($this->geocodeServiceApiUrl, $url, "The API url should be the url set via config API on legacy GeocodeService");
+
+        // lack of config value should throw an \Exception
+        Config::inst()->update( GoogleGeocodeService::class, 'google_api_url', null );
+        Config::inst()->update( 'Symbiote\\Addressable\\GeocodeService', 'google_api_url', null );
+        try {
+            $url = $service->getApiUrl();
+            $this->assertTrue(false, "Lack of an API URL should trigger an \Exception");
+        } catch (\Exception $e) {
+            // noop
+        }
+
+    }
+
+}


### PR DESCRIPTION
Hi, this PR fixes https://github.com/symbiote/silverstripe-addressable/issues/68

A false or empty string value for the GOOGLE_API_KEY  would not allow values set via project Yaml to be used.

```
$ php -a

php > $one = false;
php > $two = "my-api-key";
php > $three = null;
php > $key = $one ?? $two ?? $three;
php > var_dump($key);
bool(false)
php > $one = null;
php > $key = $one ?? $two ?? $three;
php > var_dump($key);
string(10) "my-api-key"
```

https://github.com/symbiote/silverstripe-addressable/commit/3360c6be7eb4de7bedef4e103afb5907744026d1#diff-1c4d87489a6617fc8cda2933ff1d1c3d48334614120949ac46114abce5258fdb

## Changes

+ Take into account false-y values set in configuration when retrieving API key and url values
+ Use Environment::getEnv  in place of getenv()
+ Move API key and url retrieval to their own methods
+ Add tests to suit
+ Throw an  \Exception rather than a GeocodeServiceException  when no google_api_url is found

