### PR TITLE
Modify expected coordinates to avoid failing test

### DIFF
--- a/tests/GeocodableTest.php
+++ b/tests/GeocodableTest.php
@@ -26,8 +26,8 @@ class GeocodableTest extends SapphireTest
         $record->write();
 
         $expected = [
-            'lat' => -41.2928922,
-            'lng' => 174.7789792,
+            'lat' => -41.2926516,
+            'lng' => 174.7789566
         ];
 
         $e = $record->getLastGeocodableException();


### PR DESCRIPTION
Unit test is failing as the excepted lat/lng returned from geocode API was different to the API result.

Response from https://developers.google.com/maps/documentation/javascript/examples/geocoding-simple shows these values:

```
         "formatted_address" : "101/103 Courtenay Place, Te Aro, Wellington 6011, New Zealand",
         "geometry" : {
            "location" : {
               "lat" : -41.2926516,
               "lng" : 174.7789566
            },
```

Separate to this, the API should be mocked so tests don't need to contact the remote API and contribute to quota usage + handle geocoding results changing due to rounding and such.