### PR TITLE
fix: update allowable guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "silverstripe/framework": "^4.0",
-        "guzzlehttp/guzzle": "^5.3.1|^6.2.1"
+        "guzzlehttp/guzzle": "^5.3.1|^6.2.1|^7"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
* update the allowable guzzle version to accommodate Silverstripe 4.11 gulp 7.x requirement