### PR TITLE
guzzlehttp/guzzle 7 support with silverstripe/framework 4.10.0 version restriction 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4.0",
-        "guzzlehttp/guzzle": "^5.3.1|^6.2.1"
+        "silverstripe/framework": "^4.10.0",
+        "guzzlehttp/guzzle": "^5.3.1|^6.2.1|^7"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "scripts": {

--- a/tests/GeocodableApiValuesTest.php
+++ b/tests/GeocodableApiValuesTest.php
@@ -23,7 +23,7 @@ class GeocodableApiValuesTest extends SapphireTest
     /**
      * Set up config
      */
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
         Environment::setEnv('GOOGLE_API_KEY', $this->envApiKey);
         Config::inst()->update( GoogleGeocodeService::class, 'google_api_key', $this->googleGeocodeServiceApiKey );
@@ -35,7 +35,7 @@ class GeocodableApiValuesTest extends SapphireTest
     /**
      * Reset config
      */
-    public function tearDown() {
+    public function tearDown() : void {
         parent::tearDown();
         Environment::setEnv('GOOGLE_API_KEY', false);
         Config::inst()->update( GoogleGeocodeService::class, 'google_api_key', null );


### PR DESCRIPTION
Similar to https://github.com/symbiote/silverstripe-addressable/pull/73 - here's a suggestion for updating to support guzzlehttp/guzzle:^7 plus minimum silverstripe/framework version 4.10.0 with support for the phpunit major version change.

I think this could be tagged as a minor version change, as it's backwards compatible.

